### PR TITLE
update: corrigir classe para transition-colors

### DIFF
--- a/src/components/ui/header.jsx
+++ b/src/components/ui/header.jsx
@@ -4,14 +4,14 @@ export default function Header() {
             <h2 className="text-4xl">Passa a bola</h2>
             <nav className="flex items-center justify-around">
                 <ul className="flex gap-6 text-lg">
-                    <li className="hover:text-rose-200 transition duration-200 cursor-pointer">Home</li>
-                    <li className="hover:text-rose-200 transition duration-200 cursor-pointer">Jogadoras</li>
-                    <li className="hover:text-rose-200 transition duration-200 cursor-pointer">Times</li>
-                    <li className="hover:text-rose-200 transition duration-200 cursor-pointer">Quadras</li>
+                    <li className="hover:text-rose-200 transition-colors duration-200 cursor-pointer">Home</li>
+                    <li className="hover:text-rose-200 transition-colors duration-200 cursor-pointer">Jogadoras</li>
+                    <li className="hover:text-rose-200 transition-colors duration-200 cursor-pointer">Times</li>
+                    <li className="hover:text-rose-200 transition-colors duration-200 cursor-pointer">Quadras</li>
                 </ul>
                 <ul className="flex gap-6">
-                    <li className="px-12 py-2 bg-white text-rose-500 rounded-md hover:bg-rose-100 transition duration-200 cursor-pointer">Login</li>
-                    <li className="px-8 py-2 bg-rose-700 rounded-md hover:bg-rose-800 transition duration-200 cursor-pointer">Cadastre-se</li>
+                    <li className="px-12 py-2 bg-white text-rose-500 rounded-md hover:bg-rose-100 transition-colors duration-200 cursor-pointer">Login</li>
+                    <li className="px-8 py-2 bg-rose-700 rounded-md hover:bg-rose-800 transition-colors duration-200 cursor-pointer">Cadastre-se</li>
                 </ul>
             </nav>
         </header>


### PR DESCRIPTION
Corrigido o uso da classe de transição no header: antes estava "transition", agora "transition-colors" para aplicar corretamente a animação de cor nos links.
